### PR TITLE
deny auth for blank password w/ ldap (previously just dumped)

### DIFF
--- a/lib/Mojolicious/Plugin/BasicAuthPlus.pm
+++ b/lib/Mojolicious/Plugin/BasicAuthPlus.pm
@@ -92,6 +92,7 @@ sub _check_ldap {
     my ( $self, $c, $auth, $params ) = @_;
     my ( $username, $password ) = _split_auth($auth);
 
+    return 0 unless defined $password;
     my $ldap = Authen::Simple::LDAP->new(%$params);
 
     return 1 if $ldap->authenticate( $username, $password );

--- a/t/auth-ldap.t
+++ b/t/auth-ldap.t
@@ -1,0 +1,92 @@
+use Mojo::IOLoop;
+use Test::More;
+use Test::Mojo;
+use Mojo::ByteStream 'b';
+
+# Make sure sockets are working
+plan skip_all => 'working sockets required for this test!'
+  unless Mojo::IOLoop->new->generate_port;    # Test server
+
+# we need access to a test ldap server, set some environment variables for yours, e.g.
+# setenv MOJO_TEST_LDAP_HOST ldap.someplace.com
+# setenv MOJO_TEST_LDAP_BASEDN "dc=MYDOMAIN,dc=com"
+# setenv MOJO_TEST_LDAP_USERPASS user:pass
+
+plan skip_all => 'SKIPPING LDAP TESTS, TEST ENVIRONMENT VARIABLES NOT SET'
+  unless $ENV{MOJO_TEST_LDAP_HOST} && $ENV{MOJO_TEST_LDAP_BASEDN} && $ENV{MOJO_TEST_LDAP_USERPASS};
+
+# Lite app
+use Mojolicious::Lite;
+
+# Silence
+app->log->level('error');
+
+plugin 'basic_auth_plus';
+
+# Explicit username and password
+get '/ldap-auth' => sub {
+    my $self = shift;
+
+    return $self->render(text => 'authorized')
+        if $self->basic_auth(
+            realm => {
+              # anonymous bind. on some less-standard ldap configs you might need
+              # more parameters, but this should usually work
+              host   => $ENV{MOJO_TEST_LDAP_HOST} || 'MISSINGLDAPSERVER',
+              basedn => $ENV{MOJO_TEST_LDAP_BASEDN} || 'dc=MYDOMAIN,dc=com'
+            }
+        );
+
+    $self->render(text => 'denied');
+};
+
+under sub {
+    my $self = shift;
+    return $self->basic_auth(
+        realm =>  {
+              host   => $ENV{MOJO_TEST_LDAP_HOST} || 'MISSINGLDAPSERVER',
+              basedn => $ENV{MOJO_TEST_LDAP_BASEDN} || 'dc=MYDOMAIN,dc=com'
+        });
+};
+
+get '/under-ldap-bridge' => sub {
+    shift->render(text => 'authorized');
+};
+
+
+# Tests
+my $t = Test::Mojo->new;
+my $encoded;
+
+# Fails #
+
+# Under bridge fail
+diag "ldap-auth";
+$encoded = b("bad:auth")->b64_encode->to_string;
+chop $encoded;
+$t->get_ok('/ldap-auth', {Authorization => "Basic $encoded"}, 'bad credentials')
+   ->status_is(401)->content_is('denied');
+diag "ldap bridge";
+$t->get_ok('/under-ldap-bridge', {Authorization => "Basic $encoded"}, 'bad credentials')
+   ->status_is(401)->content_is('');
+
+# blank password
+$encoded = b("bad:")->b64_encode->to_string;
+chop $encoded;
+$t->get_ok('/ldap-auth', {Authorization => "Basic $encoded"},'blank password')
+  ->status_is(401)->content_is('denied');
+
+# Successes #
+
+# Under bridge
+
+$encoded = b($ENV{MOJO_TEST_LDAP_USERPASS})->b64_encode->to_string;
+chop $encoded;
+diag '/ldap-auth';
+$t->get_ok('/ldap-auth', {Authorization => "Basic $encoded"})
+  ->status_is(200)->content_is('authorized');
+diag '/under-ldap-bridge';
+$t->get_ok('/under-ldap-bridge', {Authorization => "Basic $encoded"})
+  ->status_is(200)->content_is('authorized');
+
+done_testing;


### PR DESCRIPTION
thanks for the plugin. useful!

your version crashes and burns (500) if attempting to auth with a blank password against an ldap server. the dump points to one of the upstream modules not handling this case. i added a one-line fix that just refuses (401) to auth a blank password in ldap anonymous bind mode. i think this is an acceptable "feature"

also, i noticed you didn't have any tests for the ldap stuff. i added a test file with optional tests (direct and bridged both using anonymous bind) that only get executed if you set some environment variables first (for a working ldap host, basedn, and user:pass)

hope you find this useful
jay jay@purplewire.com
