### PR TITLE
Mojolicious error when username or password is blank

### DIFF
--- a/lib/Mojolicious/Plugin/BasicAuthPlus.pm
+++ b/lib/Mojolicious/Plugin/BasicAuthPlus.pm
@@ -102,6 +102,9 @@ sub _check_passwd {
     my ( $self, $c, $auth, $params ) = @_;
     my ( $username, $password ) = _split_auth($auth);
 
+    $username = '' unless $username;
+    $password = '' unless $password;
+
     my $passwd = Authen::Simple::Passwd->new(%$params);
 
     return 1 if $passwd->authenticate( $username, $password );


### PR DESCRIPTION
Hello,

At first, thank you for this good module.

I noticed if I used 'file' method for authentication:

``` perl
    my $auth = $r->under(sub {
            my $self = shift;

            return 1 if $self->basic_auth(
                'realm' => {
                    path => './passwordfile',
                }
            );
    });
```

and **a user leaved the password field (or both fields) as blank** and press the submit button, then
Mojolicious error occurred and several information about Perl code and internal variables are displayed
in the browser. (I tested using Chrome)

```
Parameter #1 (undef) to Authen::Simple::Passwd::authenticate was an 'undef', which is not one of the allowed types: scalar
 at /Users/gypark/perl5/perlbrew/perls/perl-5.18/lib/site_perl/5.18.1/Authen/Simple/Adapter.pm line 42.
    Authen::Simple::Adapter::authenticate(undef, undef, undef) called at /Users/gypark/perl5/perlbrew/perls/perl-5.18/lib/site_perl/5.18.1/Mojolicious/Plugin/BasicAuthPlus.pm line 110
...
```

I thought this could be a problem and it would better to handle this situation
just like the authentication failure.

I tried this patch and it seems to work well. But I'm not sure I've done correctly.

Would you please check this?

Thank you.
