### PR TITLE
Changed error check for start_tls()

### DIFF
--- a/lib/Mojolicious/Plugin/BasicAuthPlus.pm
+++ b/lib/Mojolicious/Plugin/BasicAuthPlus.pm
@@ -144,8 +144,10 @@ sub _check_ldap {
                 verify  => $params->{tls_verify} // 'optional',
                 cafile  => $params->{cafile} // '',
             );
-            if ($mesg->is_error) {
-                $c->app->log->warn("$@") if $logging;
+            if ($mesg->{code}) {
+            	my $text = "start_tls() failed for $params->{host}. " .
+            		"[$mesg->{code}] $mesg->{error_name}: $mesg->{error_text}" ;
+                $c->app->log->warn( $text ) if $logging;
                 $ldap->unbind;
                 return 0;
             }

--- a/lib/Mojolicious/Plugin/BasicAuthPlus.pm
+++ b/lib/Mojolicious/Plugin/BasicAuthPlus.pm
@@ -144,9 +144,9 @@ sub _check_ldap {
                 verify  => $params->{tls_verify} // 'optional',
                 cafile  => $params->{cafile} // '',
             );
-            if ($mesg->{code}) {
+            if ($mesg->code) {
             	my $text = "start_tls() failed for $params->{host}. " .
-            		"[$mesg->{code}] $mesg->{error_name}: $mesg->{error_text}" ;
+            		"[$mesg->code] $mesg->error_name: $mesg->error_text" ;
                 $c->app->log->warn( $text ) if $logging;
                 $ldap->unbind;
                 return 0;


### PR DESCRIPTION
The is_error method didn’t seem to work with my perl installation (5.25 vi MacPorts on Mac OS 10.13.4), so I changed the test to check mesage->{code} instead and all now seems to be well.